### PR TITLE
CVE-2022-23833 Cherry-picked c477b761804984c932704554ad35f78a2e230c6a

### DIFF
--- a/django/http/multipartparser.py
+++ b/django/http/multipartparser.py
@@ -256,6 +256,8 @@ class MultiPartParser(object):
                                 remaining = len(stripped_chunk) % 4
                                 while remaining != 0:
                                     over_chunk = field_stream.read(4 - remaining)
+                                    if not over_chunk:
+                                        break
                                     stripped_chunk += b"".join(over_chunk.split())
                                     remaining = len(stripped_chunk) % 4
 

--- a/docs/releases/1.11.29.3
+++ b/docs/releases/1.11.29.3
@@ -13,3 +13,10 @@ CVE-2022-28346: Potential SQL injection in ``QuerySet.annotate()``, ``aggregate(
 :meth:`~.QuerySet.extra` methods were subject to SQL injection in column
 aliases, using a suitably crafted dictionary, with dictionary expansion, as the
 ``**kwargs`` passed to these methods.
+
+CVE-2022-23833: Denial-of-service possibility in file uploads
+=============================================================
+
+Passing certain inputs to multipart forms could result in an infinite loop when
+parsing files.
+


### PR DESCRIPTION
[1.11.29.x] Fixed CVE-2022-23833 -- Fixed DoS possiblity in file uploads.

Thanks Alan Ryan for the report and initial patch.

Backport of fc18f36c4ab94399366ca2f2007b3692559a6f23 from main.

(cherry picked from commit c477b761804984c932704554ad35f78a2e230c6a)